### PR TITLE
Fix: Allow node >= 8 and npm >= 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "engines": {
     "node": ">=8.0.0",
-    "npm": "^5.0.0"
+    "npm": ">=5.0.0"
   },
   "homepage": "https://github.com/teamleadercrm/ui-illustrations#readme",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "^1.16.4"
   },
   "engines": {
-    "node": "^8.0.0",
+    "node": ">=8.0.0",
     "npm": "^5.0.0"
   },
   "homepage": "https://github.com/teamleadercrm/ui-illustrations#readme",


### PR DESCRIPTION
This PR will help us to get rid of the `--ignore-engines` when installing this package using yarn.