### PR TITLE
Remove redundant eslint-plugin-standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "bluebird": "^3.5.0",
     "cheerio": "^1.0.0-rc.2",
     "cli-color": "^2.0.0",
-    "eslint-plugin-standard": "^4.0.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
     "lodash.camelcase": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,11 +1598,6 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-plugin-standard@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
-  integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
-
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"


### PR DESCRIPTION
This PR removes the `eslint-plugin-standard` dependency.

The package has been made redundant, see https://github.com/standard/standard/issues/1316
