### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,5 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 3
-  reviewers:
-    - driesd
-    - ArnaudWeyts
-    - lowiebenoot
-    - JorenSaeyTL
-    - lorgan3
-    - jelledc
-    - qubis741
-    - farazatarodi
-    - stefaandevylder
   labels:
   - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 3
+  ignore:
+  - dependency-name: '*'
+    update-types: ['version-update:semver-patch']
   labels:
   - dependencies

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-- @driesd @ArnaudWeyts @lowiebenoot @JorenSaeyTL @lorgan3 @jelledc @qubis741 @farazatarodi @stefaandevylder
+- @driesd @lowiebenoot @JorenSaeyTL @lorgan3 @jelledc @qubis741 @farazatarodi @stefaandevylder @eniskraasniqi1 @KristofColpaert @BeirlaenAaron

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+- @driesd @ArnaudWeyts @lowiebenoot @JorenSaeyTL @lorgan3 @jelledc @qubis741 @farazatarodi @stefaandevylder


### PR DESCRIPTION
Use CODEOWNERS for assigning reviews instead because it's more robust

Also ignore patch updates so dependency updates are more managable