### PR TITLE
[Fix] Set correct semver version tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-illustrations",
   "description": "Teamleader UI Illustrations",
-  "version": "1.20",
+  "version": "1.20.0",
   "author": "Teamleader <development@teamleader.eu> (https://www.teamleader.eu)",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui-illustrations/issues"


### PR DESCRIPTION
### Description

Need to add a `.0` for npm to accept the version.